### PR TITLE
勤怠データの記録・集計機能の追加

### DIFF
--- a/api/.air.toml
+++ b/api/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ./cmd/server"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 FROM base AS development
 RUN go install github.com/air-verse/air@latest
 EXPOSE 8080
-CMD ["air"]
+CMD ["air", "-c", ".air.toml"]
 
 FROM base AS builder
 

--- a/api/air.toml
+++ b/api/air.toml
@@ -1,0 +1,4 @@
+root = "."
+tmp_dir = "tmp"
+build = "go build -o ./tmp/main ./cmd/server"
+cmd = "./tmp/main"

--- a/api/air.toml
+++ b/api/air.toml
@@ -1,4 +1,0 @@
-root = "."
-tmp_dir = "tmp"
-build = "go build -o ./tmp/main ./cmd/server"
-cmd = "./tmp/main"

--- a/api/cmd/seed/main.go
+++ b/api/cmd/seed/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/t2469/labor-management-system.git/config"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/seed"
+	"github.com/t2469/attendance-system.git/config"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/seed"
 	"log"
 	"time"
 )

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/t2469/labor-management-system.git/config"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/models"
-	"github.com/t2469/labor-management-system.git/routes"
+	"github.com/t2469/attendance-system.git/config"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
+	"github.com/t2469/attendance-system.git/routes"
 	"log"
 	"time"
 )

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -26,6 +26,7 @@ func main() {
 		&models.Account{},
 		&models.Attendance{},
 		&models.TimeClock{},
+		&models.WorkRecord{},
 		&models.HealthInsuranceRate{},
 		&models.PensionInsuranceRate{},
 		&models.AllowanceType{},

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -25,6 +25,7 @@ func main() {
 		&models.Employee{},
 		&models.Account{},
 		&models.Attendance{},
+		&models.TimeClock{},
 		&models.HealthInsuranceRate{},
 		&models.PensionInsuranceRate{},
 		&models.AllowanceType{},

--- a/api/controllers/account_controller.go
+++ b/api/controllers/account_controller.go
@@ -2,8 +2,8 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
 	"golang.org/x/crypto/bcrypt"
 	"net/http"
 	"time"

--- a/api/controllers/allowance_type_controller.go
+++ b/api/controllers/allowance_type_controller.go
@@ -2,9 +2,9 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/helpers"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/helpers"
+	"github.com/t2469/attendance-system.git/models"
 	"net/http"
 )
 

--- a/api/controllers/attendance_controller.go
+++ b/api/controllers/attendance_controller.go
@@ -2,8 +2,8 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
 	"net/http"
 	"time"
 )

--- a/api/controllers/auth_controller.go
+++ b/api/controllers/auth_controller.go
@@ -1,14 +1,14 @@
 package controllers
 
 import (
-	"github.com/t2469/labor-management-system.git/db"
+	"github.com/t2469/attendance-system.git/db"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/api/controllers/company_controller.go
+++ b/api/controllers/company_controller.go
@@ -2,8 +2,8 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
 	"net/http"
 )
 

--- a/api/controllers/employee_allowance_controller.go
+++ b/api/controllers/employee_allowance_controller.go
@@ -2,9 +2,9 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/helpers"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/helpers"
+	"github.com/t2469/attendance-system.git/models"
 	"net/http"
 )
 

--- a/api/controllers/employee_controller.go
+++ b/api/controllers/employee_controller.go
@@ -2,9 +2,9 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/db"
-	"github.com/t2469/labor-management-system.git/models"
-	"github.com/t2469/labor-management-system.git/services"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
+	"github.com/t2469/attendance-system.git/services"
 	"net/http"
 	"strconv"
 )

--- a/api/controllers/time_clock_controller.go
+++ b/api/controllers/time_clock_controller.go
@@ -81,3 +81,19 @@ func GetTimeClock(c *gin.Context) {
 
 	c.JSON(http.StatusOK, timeClock)
 }
+
+func GetTimeClocks(c *gin.Context) {
+	companyID, err := helpers.GetCompanyID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	var timeClocks []models.TimeClock
+	if err := db.DB.Joins("JOIN employees ON employees.id = time_clocks.employee_id").Where("employees.company_id = ?", companyID).Order("time_clocks.timestamp DESC").Find(&timeClocks).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, timeClocks)
+}

--- a/api/controllers/time_clock_controller.go
+++ b/api/controllers/time_clock_controller.go
@@ -1,9 +1,11 @@
 package controllers
 
 import (
+	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/t2469/attendance-system.git/db"
 	"github.com/t2469/attendance-system.git/models"
+	"gorm.io/gorm"
 	"net/http"
 	"time"
 )
@@ -39,4 +41,20 @@ func CreateTimeClock(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, timeClock)
+}
+
+func GetTimeClock(c *gin.Context) {
+	id := c.Param("id")
+
+	var timeClock models.TimeClock
+	if err := db.DB.First(&timeClock, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "time clock record not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, timeClock)
 }

--- a/api/controllers/time_clock_controller.go
+++ b/api/controllers/time_clock_controller.go
@@ -24,6 +24,23 @@ func CreateTimeClock(c *gin.Context) {
 		return
 	}
 
+	companyID, err := helpers.GetCompanyID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	var employee models.Employee
+	if err := db.DB.First(&employee, input.EmployeeID).Error; err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "employee not found"})
+		return
+	}
+
+	if employee.CompanyID != companyID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "you are not allowed to record time for this employee"})
+		return
+	}
+
 	// Timestampが未指定の場合、現在時刻を設定
 	eventTime := time.Now()
 	if input.Timestamp != nil {

--- a/api/controllers/time_clock_controller.go
+++ b/api/controllers/time_clock_controller.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/helpers"
 	"github.com/t2469/attendance-system.git/models"
 	"gorm.io/gorm"
 	"net/http"
@@ -53,6 +54,23 @@ func GetTimeClock(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	companyID, err := helpers.GetCompanyID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	var emp models.Employee
+	if err := db.DB.First(&emp, timeClock.EmployeeID).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve employee"})
+		return
+	}
+
+	if emp.CompanyID != companyID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "access to this record is forbidden"})
 		return
 	}
 

--- a/api/controllers/time_clock_controller.go
+++ b/api/controllers/time_clock_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"github.com/t2469/attendance-system.git/services"
 	"net/http"
 	"strconv"
 	"time"
@@ -49,6 +50,12 @@ func CreateTimeClock(c *gin.Context) {
 	}
 
 	if err := db.DB.Create(&timeClock).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	day := eventTime.In(time.Local).Truncate(24 * time.Hour)
+	if err := services.UpsertWorkRecord(input.EmployeeID, day); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/api/controllers/time_clock_controller.go
+++ b/api/controllers/time_clock_controller.go
@@ -1,0 +1,42 @@
+package controllers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
+	"net/http"
+	"time"
+)
+
+type CreateTimeClockInput struct {
+	EmployeeID uint                 `json:"employee_id" binding:"required"`
+	Type       models.TimeClockType `json:"type" binding:"required"`
+	Timestamp  *time.Time           `json:"timestamp"`
+}
+
+func CreateTimeClock(c *gin.Context) {
+	var input CreateTimeClockInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Timestampが未指定の場合、現在時刻を設定
+	eventTime := time.Now()
+	if input.Timestamp != nil {
+		eventTime = *input.Timestamp
+	}
+
+	timeClock := models.TimeClock{
+		EmployeeID: input.EmployeeID,
+		Type:       input.Type,
+		Timestamp:  eventTime,
+	}
+
+	if err := db.DB.Create(&timeClock).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, timeClock)
+}

--- a/api/controllers/work_record_controller.go
+++ b/api/controllers/work_record_controller.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type WorkRecordResponse struct {
+	ID           uint      `json:"id"`
+	EmployeeID   uint      `json:"employee_id"`
+	Date         time.Time `json:"date"`
+	ClockIn      time.Time `json:"clock_in"`
+	ClockOut     time.Time `json:"clock_out"`
+	BreakMinutes int64     `json:"break_minutes"`
+	WorkMinutes  int64     `json:"work_minutes"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func GetWorkRecords(c *gin.Context) {
+	empIDStr := c.Query("employee_id")
+	if empIDStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "employee_id is required"})
+		return
+	}
+
+	empID, err := strconv.Atoi(empIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid employee_id"})
+		return
+	}
+
+	var records []models.WorkRecord
+	if err := db.DB.
+		Where("employee_id = ?", empID).
+		Order("date ASC").
+		Find(&records).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	var response []WorkRecordResponse
+	for _, r := range records {
+		response = append(response, WorkRecordResponse{
+			ID:           r.ID,
+			EmployeeID:   r.EmployeeID,
+			Date:         r.Date,
+			ClockIn:      r.ClockIn,
+			ClockOut:     r.ClockOut,
+			BreakMinutes: r.BreakMinutes,
+			WorkMinutes:  r.WorkMinutes,
+			CreatedAt:    r.CreatedAt,
+			UpdatedAt:    r.UpdatedAt,
+		})
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/api/db/db.go
+++ b/api/db/db.go
@@ -19,9 +19,17 @@ func InitDB() {
 	password := os.Getenv("DB_PASSWORD")
 	dbname := os.Getenv("DB_NAME")
 
+	env := os.Getenv("GO_ENV")
 	sslmode := "disable"
-	if os.Getenv("GO_ENV") == "production" {
+	if env == "production" {
 		sslmode = "require"
+	}
+
+	var logLv logger.LogLevel
+	if env == "production" {
+		logLv = logger.Warn
+	} else {
+		logLv = logger.Info
 	}
 
 	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s TimeZone=Asia/Tokyo",
@@ -31,10 +39,10 @@ func InitDB() {
 		log.New(os.Stdout, "\r\n", log.LstdFlags),
 		logger.Config{
 			SlowThreshold:             time.Second,
-			LogLevel:                  logger.Info,
+			LogLevel:                  logLv,
 			IgnoreRecordNotFoundError: true,
 			ParameterizedQueries:      true,
-			Colorful:                  true,
+			Colorful:                  env != "production",
 		},
 	)
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,4 +1,4 @@
-module github.com/t2469/labor-management-system.git
+module github.com/t2469/attendance-system.git
 
 go 1.23.6
 

--- a/api/helpers/authz.go
+++ b/api/helpers/authz.go
@@ -1,0 +1,21 @@
+package helpers
+
+import (
+	"errors"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
+)
+
+// CheckEmployeeAccess 指定された従業員が会社に属しているかを確認するためのメソッド
+func CheckEmployeeAccess(employeeID uint, companyID uint) error {
+	var employee models.Employee
+	if err := db.DB.First(&employee, employeeID).Error; err != nil {
+		return errors.New("employee not found")
+	}
+
+	if employee.CompanyID != companyID {
+		return errors.New("you are not allowed to access this employee")
+	}
+
+	return nil
+}

--- a/api/models/allowance_type.go
+++ b/api/models/allowance_type.go
@@ -6,7 +6,7 @@ type AllowanceType struct {
 	ID             uint      `gorm:"primaryKey" json:"id"`
 	CompanyID      uint      `json:"company_id"`
 	Name           string    `gorm:"not null" json:"name"`
-	Type           string    `json:"type"`
+	Type           string    `gorm:"not null;check:type IN ('commission','fixed')" json:"type"`
 	Description    string    `json:"description"`
 	CommissionRate float64   `json:"commission_rate"`
 	CreatedAt      time.Time `json:"created_at"`

--- a/api/models/time_clock.go
+++ b/api/models/time_clock.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type TimeClockType string
+
+const (
+	ClockIn    TimeClockType = "clock_in"
+	ClockOut   TimeClockType = "clock_out"
+	BreakBegin TimeClockType = "break_begin"
+	BreakEnd   TimeClockType = "break_end"
+)
+
+type TimeClock struct {
+	ID         uint          `gorm:"primaryKey" json:"id"`
+	EmployeeID uint          `gorm:"not null" json:"employee_id"`
+	Type       TimeClockType `gorm:"not null;check:type IN ('clock_in','clock_out','break_begin','break_end')" json:"type"`
+	Timestamp  time.Time     `gorm:"not null" json:"timestamp"`
+	CreatedAt  time.Time     `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (tc *TimeClock) BeforeCreate(tx *gorm.DB) (err error) {
+	return tc.validate()
+}
+
+func (tc *TimeClock) BeforeUpdate(tx *gorm.DB) (err error) {
+	return tc.validate()
+}
+
+// 想定されたType以外をDBに保存しないためのバリデーション
+func (tc *TimeClock) validate() error {
+	switch tc.Type {
+	case ClockIn, ClockOut, BreakBegin, BreakEnd:
+		return nil
+	default:
+		return errors.New("invalid time clock type: " + string(tc.Type))
+	}
+}

--- a/api/models/work_record.go
+++ b/api/models/work_record.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+type WorkRecord struct {
+	ID            uint          `gorm:"primaryKey" json:"id"`
+	EmployeeID    uint          `gorm:"not null" json:"employee_id"`
+	Date          time.Time     `gorm:"type:date;not null" json:"date"`
+	ClockIn       time.Time     `json:"clock_in"`
+	ClockOut      time.Time     `json:"clock_out"`
+	BreakDuration time.Duration `json:"break_duration"`
+	WorkDuration  time.Duration `json:"work_duration"`
+	CreatedAt     time.Time     `json:"created_at"`
+	UpdatedAt     time.Time     `json:"updated_at"`
+}

--- a/api/models/work_record.go
+++ b/api/models/work_record.go
@@ -3,13 +3,13 @@ package models
 import "time"
 
 type WorkRecord struct {
-	ID            uint          `gorm:"primaryKey" json:"id"`
-	EmployeeID    uint          `gorm:"not null" json:"employee_id"`
-	Date          time.Time     `gorm:"type:date;not null" json:"date"`
-	ClockIn       time.Time     `json:"clock_in"`
-	ClockOut      time.Time     `json:"clock_out"`
-	BreakDuration time.Duration `json:"break_duration"`
-	WorkDuration  time.Duration `json:"work_duration"`
-	CreatedAt     time.Time     `json:"created_at"`
-	UpdatedAt     time.Time     `json:"updated_at"`
+	ID           uint      `gorm:"primaryKey" json:"id"`
+	EmployeeID   uint      `gorm:"not null" json:"employee_id"`
+	Date         time.Time `gorm:"type:date;not null" json:"date"`
+	ClockIn      time.Time `json:"clock_in"`
+	ClockOut     time.Time `json:"clock_out"`
+	BreakMinutes int64     `json:"break_minutes"`
+	WorkMinutes  int64     `json:"work_minutes"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }

--- a/api/routes/allowances.go
+++ b/api/routes/allowances.go
@@ -2,8 +2,8 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/controllers"
-	"github.com/t2469/labor-management-system.git/middleware"
+	"github.com/t2469/attendance-system.git/controllers"
+	"github.com/t2469/attendance-system.git/middleware"
 )
 
 func addAllowanceRoutes(router *gin.Engine) {

--- a/api/routes/auth_routes.go
+++ b/api/routes/auth_routes.go
@@ -2,8 +2,8 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/controllers"
-	"github.com/t2469/labor-management-system.git/middleware"
+	"github.com/t2469/attendance-system.git/controllers"
+	"github.com/t2469/attendance-system.git/middleware"
 )
 
 func addAuthRoutes(router *gin.Engine) {

--- a/api/routes/companies.go
+++ b/api/routes/companies.go
@@ -3,11 +3,10 @@ package routes
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/t2469/labor-management-system.git/controllers"
-	"github.com/t2469/labor-management-system.git/middleware"
 )
 
 func addCompanyRoutes(router *gin.Engine) {
-	companies := router.Group("/companies", middleware.AuthMiddleware())
+	companies := router.Group("/companies")
 	{
 		companies.POST("", controllers.CreateCompany)
 	}

--- a/api/routes/companies.go
+++ b/api/routes/companies.go
@@ -2,7 +2,7 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/controllers"
+	"github.com/t2469/attendance-system.git/controllers"
 )
 
 func addCompanyRoutes(router *gin.Engine) {

--- a/api/routes/employees.go
+++ b/api/routes/employees.go
@@ -2,8 +2,8 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/controllers"
-	"github.com/t2469/labor-management-system.git/middleware"
+	"github.com/t2469/attendance-system.git/controllers"
+	"github.com/t2469/attendance-system.git/middleware"
 )
 
 func addEmployeeRoutes(router *gin.Engine) {

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -28,6 +28,7 @@ func setupRouter(cfg *config.Config) *gin.Engine {
 	addCompanyRoutes(router)
 	addAllowanceRoutes(router)
 	addAuthRoutes(router)
+	addTimeClockRoutes(router)
 
 	return router
 }

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -3,7 +3,7 @@ package routes
 import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	"github.com/t2469/labor-management-system.git/config"
+	"github.com/t2469/attendance-system.git/config"
 	"log"
 	"net/http"
 	"time"

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -29,6 +29,7 @@ func setupRouter(cfg *config.Config) *gin.Engine {
 	addAllowanceRoutes(router)
 	addAuthRoutes(router)
 	addTimeClockRoutes(router)
+	addWorkRecordRoutes(router)
 
 	return router
 }

--- a/api/routes/time_clock_routes.go
+++ b/api/routes/time_clock_routes.go
@@ -1,0 +1,14 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/t2469/attendance-system.git/controllers"
+	"github.com/t2469/attendance-system.git/middleware"
+)
+
+func addTimeClockRoutes(router *gin.Engine) {
+	timeClocks := router.Group("/time_clocks", middleware.AuthMiddleware())
+	{
+		timeClocks.POST("", controllers.CreateTimeClock)
+	}
+}

--- a/api/routes/time_clock_routes.go
+++ b/api/routes/time_clock_routes.go
@@ -10,5 +10,6 @@ func addTimeClockRoutes(router *gin.Engine) {
 	timeClocks := router.Group("/time_clocks", middleware.AuthMiddleware())
 	{
 		timeClocks.POST("", controllers.CreateTimeClock)
+		timeClocks.GET("/:id", controllers.GetTimeClock)
 	}
 }

--- a/api/routes/time_clock_routes.go
+++ b/api/routes/time_clock_routes.go
@@ -10,6 +10,7 @@ func addTimeClockRoutes(router *gin.Engine) {
 	timeClocks := router.Group("/time_clocks", middleware.AuthMiddleware())
 	{
 		timeClocks.POST("", controllers.CreateTimeClock)
+		timeClocks.GET("", controllers.GetTimeClocks)
 		timeClocks.GET("/:id", controllers.GetTimeClock)
 	}
 }

--- a/api/routes/work_record_routes.go
+++ b/api/routes/work_record_routes.go
@@ -1,0 +1,14 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/t2469/attendance-system.git/controllers"
+	"github.com/t2469/attendance-system.git/middleware"
+)
+
+func addWorkRecordRoutes(router *gin.Engine) {
+	workRecords := router.Group("/work_records", middleware.AuthMiddleware())
+	{
+		workRecords.GET("", controllers.GetWorkRecords)
+	}
+}

--- a/api/seed/attendance_seed.go
+++ b/api/seed/attendance_seed.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"gorm.io/gorm"
 )
 

--- a/api/seed/company_seed.go
+++ b/api/seed/company_seed.go
@@ -3,7 +3,7 @@ package seed
 import (
 	"log"
 
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"gorm.io/gorm"
 )
 

--- a/api/seed/employee_seed.go
+++ b/api/seed/employee_seed.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"gorm.io/gorm"
 )
 

--- a/api/seed/insurance_rate_seed.go
+++ b/api/seed/insurance_rate_seed.go
@@ -2,7 +2,7 @@ package seed
 
 import (
 	"fmt"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"github.com/xuri/excelize/v2"
 	"gorm.io/gorm"
 	"log"

--- a/api/seed/prefecture_seed.go
+++ b/api/seed/prefecture_seed.go
@@ -1,7 +1,7 @@
 package seed
 
 import (
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"log"
 
 	"gorm.io/gorm"

--- a/api/services/health_insurance_service.go
+++ b/api/services/health_insurance_service.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"errors"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"gorm.io/gorm"
 	"sort"
 )

--- a/api/services/payroll_service.go
+++ b/api/services/payroll_service.go
@@ -1,7 +1,7 @@
 package services
 
 import (
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"gorm.io/gorm"
 	"log"
 )

--- a/api/services/pension_insurance_service.go
+++ b/api/services/pension_insurance_service.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"errors"
-	"github.com/t2469/labor-management-system.git/models"
+	"github.com/t2469/attendance-system.git/models"
 	"gorm.io/gorm"
 	"sort"
 )

--- a/api/services/work_record_service.go
+++ b/api/services/work_record_service.go
@@ -1,0 +1,76 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
+	"gorm.io/gorm"
+)
+
+func UpsertWorkRecord(empID uint, date time.Time) error {
+	from := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.Local)
+	to := from.AddDate(0, 0, 1)
+
+	// 対象日の TimeClock レコードを取得
+	var clocks []models.TimeClock
+	if err := db.DB.
+		Where("employee_id = ? AND timestamp >= ? AND timestamp < ?", empID, from, to).
+		Order("timestamp ASC").
+		Find(&clocks).Error; err != nil {
+		return err
+	}
+
+	var clockIn, clockOut time.Time
+	var breakDuration time.Duration
+	var breakStart *time.Time
+
+	for _, clock := range clocks {
+		switch clock.Type {
+		case models.ClockIn:
+			if clockIn.IsZero() {
+				clockIn = clock.Timestamp
+			}
+		case models.ClockOut:
+			clockOut = clock.Timestamp
+		case models.BreakBegin:
+			breakStart = &clock.Timestamp
+		case models.BreakEnd:
+			if breakStart != nil {
+				breakDuration += clock.Timestamp.Sub(*breakStart)
+				breakStart = nil
+			}
+		}
+	}
+
+	// clockIn/clockOut が揃っていれば、実働時間を計算。なければ 0
+	workDuration := time.Duration(0)
+	if !clockIn.IsZero() && !clockOut.IsZero() && clockOut.After(clockIn) {
+		workDuration = clockOut.Sub(clockIn) - breakDuration
+	}
+
+	// 該当日の WorkRecord を検索し、なければ作成、あれば更新
+	var wr models.WorkRecord
+	err := db.DB.Where("employee_id = ? AND date = ?", empID, from).First(&wr).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		wr = models.WorkRecord{
+			EmployeeID:    empID,
+			Date:          from,
+			ClockIn:       clockIn,
+			ClockOut:      clockOut,
+			BreakDuration: breakDuration,
+			WorkDuration:  workDuration,
+		}
+		return db.DB.Create(&wr).Error
+	} else if err != nil {
+		return err
+	}
+
+	wr.ClockIn = clockIn
+	wr.ClockOut = clockOut
+	wr.BreakDuration = breakDuration
+	wr.WorkDuration = workDuration
+
+	return db.DB.Save(&wr).Error
+}

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>attendance-system</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/pages/admin/AllowanceTypesPage.tsx
+++ b/web/src/pages/admin/AllowanceTypesPage.tsx
@@ -58,14 +58,20 @@ export default function AllowanceTypesPage() {
                         </div>
                         <div>
                             <Label className="mb-1 text-gray-800">タイプ</Label>
-                            <Input
+                            <select
                                 required
+                                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black focus:border-black transition"
                                 value={edit ? edit.type : form.type}
-                                onChange={e => edit
-                                    ? setEdit({...edit, type: e.target.value})
-                                    : setForm({...form, type: e.target.value})
+                                onChange={(e) =>
+                                    edit
+                                        ? setEdit({...edit, type: e.target.value})
+                                        : setForm({...form, type: e.target.value})
                                 }
-                            />
+                            >
+                                <option value="">選択してください</option>
+                                <option value="commission">歩合制</option>
+                                <option value="fixed">固定額</option>
+                            </select>
                         </div>
                         <div>
                             <Label className="mb-1 text-gray-800">説明</Label>


### PR DESCRIPTION
## 変更内容

### モジュールと import パスの更新

- `api/go.mod` のモジュール名を `github.com/t2469/labor-management-system.git` から `github.com/t2469/attendance-system.git` に変更  
- プロジェクト内の各ファイルで使用していた import パスを、新しいモジュール名に合わせて変更 [[1]](diffhunk://#diff-643644467cfaae04ed2ecdf79f24eb3b919d263ee20e3c14e87275ae5a3b7ea2L4-R6) など複数に変更

---

### 開発用設定の更新

- ホットリロード用ツール Air の設定ファイル `.air.toml` を新規追加  
- `api/Dockerfile` の `CMD` を新しい Air 設定を使うように変更

---

### DBとロギングの改善

- `api/db/db.go` の `InitDB` 関数にて、環境ごとにログレベルを切り替える処理を追加  
- `AllowanceType` モデルの `Type` フィールドに、`commission` または `fixed` のどちらかしか許可しないチェック制約を追加に変更

---

### 新機能の追加

- `TimeClock` モデルと `WorkRecord` モデルを新規追加し、打刻と勤務記録を管理できるように変更 [[1]](diffhunk://#diff-248889cfee8c31215770d81e1a207507dbccf2bc0c4e9da8c05ff484ae41ff6bR1-R43)  
- 打刻および勤務記録の登録・取得用のコントローラーを実装し、API エンドポイントを追加に変更 [[1]](diffhunk://#diff-6ab5b7155633c7c74f5cc2c749305453b167b2af86f987cc4ab5e857a88c941aR1-R136)

---

### モデル・コントローラーの追加

- 打刻管理用の `TimeClock` モデルと、日次集計用の `WorkRecord` モデルを追加  
- 上記モデルに対応したコントローラーを実装し、RESTful な操作ができるように変更 [[1]](diffhunk://#diff-0ffd0b08d18abc3a7bbabe710519917ced524aa8eebacf44af6aff55424b82d2R1-R85)

---
