### PR TITLE
打刻申請・修正機能（API）

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -27,6 +27,7 @@ func main() {
 		&models.Attendance{},
 		&models.TimeClock{},
 		&models.WorkRecord{},
+		&models.ClockRequest{},
 		&models.HealthInsuranceRate{},
 		&models.PensionInsuranceRate{},
 		&models.AllowanceType{},

--- a/api/controllers/clock_request_controller.go
+++ b/api/controllers/clock_request_controller.go
@@ -204,3 +204,66 @@ func ApproveClockRequest(c *gin.Context) {
 		"request": req,
 	})
 }
+
+// RejectClockRequest は打刻修正申請を却下する（管理者のみ）
+func RejectClockRequest(c *gin.Context) {
+	// リクエストIDをURLパラメータから取得
+	reqID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request id"})
+		return
+	}
+
+	// JWTトークンから認証情報を取得
+	accountID, err := helpers.GetAccountID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	isAdmin, err := helpers.GetIsAdmin(c)
+	if err != nil || !isAdmin {
+		c.JSON(http.StatusForbidden, gin.H{"error": "admin access required"})
+		return
+	}
+	companyID, err := helpers.GetCompanyID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	// 対象のClockRequestをDBから取得
+	var req models.ClockRequest
+	if err := db.DB.First(&req, reqID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "request not found"})
+		return
+	}
+
+	// すでに処理済みの場合はエラー
+	if req.Status != models.Pending {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "request already reviewed"})
+		return
+	}
+
+	// 対象の従業員が同一会社に属しているか確認
+	var emp models.Employee
+	if err := db.DB.First(&emp, req.EmployeeID).Error; err != nil || emp.CompanyID != companyID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not allowed to review request for this employee"})
+		return
+	}
+
+	// 却下処理（打刻の更新やWorkRecordの再計算は行わず、申請状態のみ更新）
+	now := time.Now()
+	req.Status = models.Rejected
+	req.ReviewedBy = &accountID
+	req.ReviewedAt = &now
+
+	if err := db.DB.Save(&req).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update request"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "request rejected",
+		"request": req,
+	})
+}

--- a/api/controllers/clock_request_controller.go
+++ b/api/controllers/clock_request_controller.go
@@ -5,8 +5,10 @@ import (
 	"github.com/t2469/attendance-system.git/db"
 	"github.com/t2469/attendance-system.git/helpers"
 	"github.com/t2469/attendance-system.git/models"
+	"github.com/t2469/attendance-system.git/services"
 	"net/http"
 	"strconv"
+	"time"
 )
 
 type ClockRequestInput struct {
@@ -117,4 +119,88 @@ func GetClockRequests(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, requests)
+}
+
+// ApproveClockRequest は打刻修正申請を承認し、TimeClockとWorkRecordを更新する（管理者専用）
+func ApproveClockRequest(c *gin.Context) {
+	// パスパラメータからリクエストIDを取得
+	reqID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request id"})
+		return
+	}
+
+	// JWTトークンから認証情報を取得
+	accountID, err := helpers.GetAccountID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	isAdmin, err := helpers.GetIsAdmin(c)
+	if err != nil || !isAdmin {
+		c.JSON(http.StatusForbidden, gin.H{"error": "admin access required"})
+		return
+	}
+	companyID, err := helpers.GetCompanyID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	// 対象の修正申請を取得
+	var req models.ClockRequest
+	if err := db.DB.First(&req, reqID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "request not found"})
+		return
+	}
+
+	// 既にレビュー済みならエラー
+	if req.Status != models.Pending {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "request already reviewed"})
+		return
+	}
+
+	// 対象の従業員が同一会社に属しているか確認
+	var emp models.Employee
+	if err := db.DB.First(&emp, req.EmployeeID).Error; err != nil || emp.CompanyID != companyID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not allowed to review request for this employee"})
+		return
+	}
+
+	// 修正対象のTimeClockを取得
+	var clock models.TimeClock
+	if err := db.DB.First(&clock, req.ClockID).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "original clock not found"})
+		return
+	}
+
+	// 打刻の内容を申請内容で更新
+	clock.Type = req.Type
+	clock.Timestamp = req.Time
+	if err := db.DB.Save(&clock).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update clock"})
+		return
+	}
+
+	// 該当日の WorkRecord を再集計
+	day := clock.Timestamp.In(time.Local).Truncate(24 * time.Hour)
+	if err := services.UpsertWorkRecord(req.EmployeeID, day); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update work record"})
+		return
+	}
+
+	// 申請ステータスを更新
+	now := time.Now()
+	req.Status = models.Approved
+	req.ReviewedBy = &accountID
+	req.ReviewedAt = &now
+	if err := db.DB.Save(&req).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update request"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "request approved",
+		"request": req,
+	})
 }

--- a/api/controllers/clock_request_controller.go
+++ b/api/controllers/clock_request_controller.go
@@ -1,0 +1,85 @@
+package controllers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/helpers"
+	"github.com/t2469/attendance-system.git/models"
+	"net/http"
+	"strconv"
+)
+
+type ClockRequestInput struct {
+	EmployeeID uint   `json:"employee_id" binding:"required"`
+	Type       string `json:"type" binding:"required"`
+	Time       string `json:"time" binding:"required"`
+	Reason     string `json:"reason"`
+}
+
+func CreateClockRequest(c *gin.Context) {
+	// URLパラメータから対象の打刻IDを取得
+	clkID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid clock id"})
+		return
+	}
+
+	var input ClockRequestInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 打刻種別を TimeClockType に変換
+	tcType := models.TimeClockType(input.Type)
+	switch tcType {
+	case models.ClockIn, models.ClockOut, models.BreakBegin, models.BreakEnd:
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid time clock type: " + input.Type})
+		return
+	}
+
+	// トークンから会社IDを取得
+	compID, err := helpers.GetCompanyID(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	// リクエストされた社員IDが、その会社に属しているかチェック
+	if err := helpers.CheckEmployeeAccess(input.EmployeeID, compID); err != nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 対象のTimeClockが存在し、かつその社員のものであるかチェック
+	var clk models.TimeClock
+	if err := db.DB.First(&clk, clkID).Error; err != nil || clk.EmployeeID != input.EmployeeID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not allowed to request change for this clock"})
+		return
+	}
+
+	// リクエストされた時刻をパースする
+	reqTime, err := helpers.ParseTimestamp(input.Time)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid time format"})
+		return
+	}
+
+	// ClockRequestを作成（StatusはデフォルトでPending）
+	req := models.ClockRequest{
+		EmployeeID: input.EmployeeID,
+		ClockID:    uint(clkID),
+		Type:       tcType,
+		Time:       reqTime,
+		Status:     models.Pending,
+		Reason:     input.Reason,
+	}
+
+	if err := db.DB.Create(&req).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, req)
+}

--- a/api/helpers/datetime.go
+++ b/api/helpers/datetime.go
@@ -1,0 +1,8 @@
+package helpers
+
+import "time"
+
+// ParseTimestamp 文字列で渡されたタイムスタンプをtime.Timeに変換する。
+func ParseTimestamp(ts string) (time.Time, error) {
+	return time.Parse(time.RFC3339, ts)
+}

--- a/api/helpers/jwt.go
+++ b/api/helpers/jwt.go
@@ -32,3 +32,18 @@ func GetAccountID(c *gin.Context) (uint, error) {
 
 	return 0, errors.New("account_id is invalid")
 }
+
+// GetIsAdmin JWTから管理者フラグ(is_admin)を取得
+func GetIsAdmin(c *gin.Context) (bool, error) {
+	val, exists := c.Get("is_admin")
+	if !exists {
+		return false, errors.New("is_admin not found in JWT")
+	}
+
+	isAdmin, ok := val.(bool)
+	if !ok {
+		return false, errors.New("is_admin flag is invalid")
+	}
+
+	return isAdmin, nil
+}

--- a/api/helpers/jwt.go
+++ b/api/helpers/jwt.go
@@ -18,3 +18,17 @@ func GetCompanyID(c *gin.Context) (uint, error) {
 
 	return 0, errors.New("company_id is not a valid number")
 }
+
+// GetAccountID JWTからaccount_idを取得
+func GetAccountID(c *gin.Context) (uint, error) {
+	val, exists := c.Get("account_id")
+	if !exists {
+		return 0, errors.New("account_id not found in JWT")
+	}
+
+	if f, ok := val.(float64); ok {
+		return uint(f), nil
+	}
+
+	return 0, errors.New("account_id is invalid")
+}

--- a/api/models/clock_request.go
+++ b/api/models/clock_request.go
@@ -1,6 +1,11 @@
 package models
 
-import "time"
+import (
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type RequestStatus string
 
@@ -9,6 +14,12 @@ const (
 	Approved RequestStatus = "approved"
 	Rejected RequestStatus = "rejected"
 )
+
+var validStatuses = map[RequestStatus]bool{
+	Pending:  true,
+	Approved: true,
+	Rejected: true,
+}
 
 type ClockRequest struct {
 	ID         uint          `gorm:"primaryKey"`
@@ -22,4 +33,19 @@ type ClockRequest struct {
 	ReviewedAt *time.Time
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
+}
+
+func (r *ClockRequest) BeforeCreate(tx *gorm.DB) error {
+	return r.validate()
+}
+
+func (r *ClockRequest) BeforeUpdate(tx *gorm.DB) error {
+	return r.validate()
+}
+
+func (r *ClockRequest) validate() error {
+	if !validStatuses[r.Status] {
+		return errors.New("invalid request status: " + string(r.Status))
+	}
+	return nil
 }

--- a/api/models/clock_request.go
+++ b/api/models/clock_request.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+type RequestStatus string
+
+const (
+	Pending  RequestStatus = "pending"
+	Approved RequestStatus = "approved"
+	Rejected RequestStatus = "rejected"
+)
+
+type ClockRequest struct {
+	ID         uint          `gorm:"primaryKey"`
+	EmployeeID uint          `gorm:"not null"`
+	ClockID    uint          `gorm:"not null"`
+	Type       TimeClockType `gorm:"type:varchar(20);not null"`
+	Time       time.Time     `gorm:"not null"`
+	Status     RequestStatus `gorm:"type:varchar(20);default:'pending'"`
+	Reason     string        `gorm:"type:text"`
+	ReviewedBy *uint
+	ReviewedAt *time.Time
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}

--- a/api/models/clock_request.go
+++ b/api/models/clock_request.go
@@ -30,6 +30,7 @@ type ClockRequest struct {
 	Status     RequestStatus `gorm:"type:varchar(20);default:'pending'"`
 	Reason     string        `gorm:"type:text"`
 	ReviewedBy *uint
+	Reviewer   *Account `gorm:"foreignKey:ReviewedBy"`
 	ReviewedAt *time.Time
 	CreatedAt  time.Time
 	UpdatedAt  time.Time

--- a/api/models/clock_request.go
+++ b/api/models/clock_request.go
@@ -44,8 +44,17 @@ func (r *ClockRequest) BeforeUpdate(tx *gorm.DB) error {
 }
 
 func (r *ClockRequest) validate() error {
+	// status
 	if !validStatuses[r.Status] {
 		return errors.New("invalid request status: " + string(r.Status))
 	}
+
+	// type
+	switch r.Type {
+	case ClockIn, ClockOut, BreakBegin, BreakEnd:
+	default:
+		return errors.New("invalid time clock type: " + string(r.Type))
+	}
+
 	return nil
 }

--- a/api/routes/clock_request_routes.go
+++ b/api/routes/clock_request_routes.go
@@ -11,5 +11,6 @@ func addClockRequestRoutes(router *gin.Engine) {
 	{
 		requests.GET("", controllers.GetClockRequests)
 		requests.POST("/:id/approve", controllers.ApproveClockRequest)
+		requests.POST("/:id/reject", controllers.RejectClockRequest)
 	}
 }

--- a/api/routes/clock_request_routes.go
+++ b/api/routes/clock_request_routes.go
@@ -10,5 +10,6 @@ func addClockRequestRoutes(router *gin.Engine) {
 	requests := router.Group("/clock_requests", middleware.AuthMiddleware())
 	{
 		requests.GET("", controllers.GetClockRequests)
+		requests.POST("/:id/approve", controllers.ApproveClockRequest)
 	}
 }

--- a/api/routes/clock_request_routes.go
+++ b/api/routes/clock_request_routes.go
@@ -1,0 +1,14 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/t2469/attendance-system.git/controllers"
+	"github.com/t2469/attendance-system.git/middleware"
+)
+
+func addClockRequestRoutes(router *gin.Engine) {
+	requests := router.Group("/clock_requests", middleware.AuthMiddleware())
+	{
+		requests.GET("", controllers.GetClockRequests)
+	}
+}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -30,6 +30,7 @@ func setupRouter(cfg *config.Config) *gin.Engine {
 	addAuthRoutes(router)
 	addTimeClockRoutes(router)
 	addWorkRecordRoutes(router)
+	addClockRequestRoutes(router)
 
 	return router
 }

--- a/api/routes/time_clock_routes.go
+++ b/api/routes/time_clock_routes.go
@@ -12,5 +12,7 @@ func addTimeClockRoutes(router *gin.Engine) {
 		timeClocks.POST("", controllers.CreateTimeClock)
 		timeClocks.GET("", controllers.GetTimeClocks)
 		timeClocks.GET("/:id", controllers.GetTimeClock)
+
+		timeClocks.POST("/:id/requests", controllers.CreateClockRequest)
 	}
 }


### PR DESCRIPTION
## 変更内容
勤怠システムにおける打刻修正申請の管理機能を追加  
主な変更点は、`ClockRequest` モデルの追加、申請処理用コントローラ関数の実装、ルーティングの更新による新機能の対応

### 新機能：打刻修正申請の管理

* **モデルの追加:**
  * [`api/models/clock_request.go`](diffhunk://#diff-f6c377dfd9ad12185c8eed446f7b4183acfe807c751a3022918083a17a006b12R1-R61): 打刻修正申請を表す `ClockRequest` モデルを追加（従業員ID、対象打刻ID、種別、時刻、ステータス、理由、レビュー情報などのフィールドを含む）

* **コントローラ関数:**
  * [`api/controllers/clock_request_controller.go`](diffhunk://#diff-1e5ce798f277c12b1e6dd8f51872f3c5cf5e2c3e405be6859731965e934c02dbR1-R269): 打刻修正申請の作成・取得・承認・却下を行う関数を追加（バリデーション、認可、DB操作などを実装）

* **ヘルパー関数:**
  * [`api/helpers/datetime.go`](diffhunk://#diff-9429cebabb7444c28137b7f19ca30c4aa64b0b43e62974e0393aab38b7f8ea97R1-R8): 文字列のタイムスタンプを `time.Time` に変換する `ParseTimestamp` 関数を追加
  * [`api/helpers/jwt.go`](diffhunk://#diff-4dcca3410a538e5a80f5832696ca7435f8331f5eb9b4dc230e361e0d354287ebR21-R49): JWT からアカウントIDと管理者フラグを取得する `GetAccountID` および `GetIsAdmin` 関数を追加

* **ルートの更新:**
  * [`api/routes/clock_request_routes.go`](diffhunk://#diff-40a2a832e27e168cb144c60ffbc68e7f14ad5d005ab9749d26c33f68f64d8149R1-R16): 打刻修正申請の一覧取得・承認・却下用エンドポイントを追加
  * [`api/routes/routes.go`](diffhunk://#diff-ccf3ebd543351a5078f7df36e3a4e9c706261f66aace5d3c6d30abe3e885591eR33): メインのルーティングに打刻修正申請ルートを統合に変更
  * [`api/routes/time_clock_routes.go`](diffhunk://#diff-cf13e2163266d1cb2e2f3cda21e89fc3dc5c10b539559adb2d421aba0283f622R15-R16): 特定の打刻に対して修正申請を作成するルートを追加

* **メイン関数:**
  * [`api/cmd/server/main.go`](diffhunk://#diff-5498418e0bec128da0a59636157a053cdfa5fe63972616aeae2320fbf5c2feb4R30): `ClockRequest` モデルをDBスキーマに含めるため、メイン関数で登録に変更

