### PR TITLE
feat(terraform): add LINE env vars (#49)

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -78,7 +78,9 @@ resource "aws_ecs_task_definition" "api_task" {
         { name = "DB_NAME", value = var.db_name },
         { name = "GO_ENV", value = "production" },
         { name = "JWT_SECRET", value = var.jwt_secret },
-        { name = "ALLOWED_ORIGIN", value = var.allowed_origin }
+        { name = "ALLOWED_ORIGIN", value = var.allowed_origin },
+        { name = "LINE_CHANNEL_SECRET", value = var.line_channel_secret },
+        { name = "LINE_CHANNEL_ACCESS_TOKEN", value = var.line_channel_access_token }
       ]
       logConfiguration = {
         logDriver = "awslogs"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -82,6 +82,18 @@ variable "db_name" {
   sensitive   = true
 }
 
+variable "line_channel_secret" {
+  description = "Line channel secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "line_channel_access_token" {
+  description = "Line_channel_access_token"
+  type        = string
+  sensitive   = true
+}
+
 variable "admin_ip" {
   description = "Administrator's public IP address"
   type        = string


### PR DESCRIPTION
### 環境変数の追加

- [`infra/ecs.tf`](diffhunk://#diff-89498805c3e11f56b65cc7c20eb36471b52a76f75794dc3664f05023dc18dddeL81-R83):  
  ECS タスク定義に `LINE_CHANNEL_SECRET` および`LINE_CHANNEL_ACCESS_TOKEN` の環境変数を追加。

---

### 変数設定の更新

- [`infra/variables.tf`](diffhunk://#diff-30fe74258ad2557f528a4280352e0c5d381ff200ed8637a82686da950316b0c8R85-R96):  
  Terraform 設定ファイルに `line_channel_secret` および `line_channel_access_token` の変数定義を追加。
