### PR TITLE
LINEによる打刻機能

### DIFF
--- a/api/controllers/line_controller.go
+++ b/api/controllers/line_controller.go
@@ -17,9 +17,12 @@ import (
 type lineCmd func(e webhook.MessageEvent, tokens []string)
 
 var cmdMap = map[string]lineCmd{
-	"テスト": test,
-	"登録":   register,
-	"出勤":   clockIn,
+	"登録":     register,
+	"テスト":   test,
+	"出勤":     clockIn,
+	"退勤":     clockOut,
+	"休憩開始": breakBegin,
+	"休憩終了": breakEnd,
 }
 
 func usage() string {
@@ -31,6 +34,9 @@ func usage() string {
 	helps := []help{
 		{"登録 <社員ID> <名前>", "従業員とLINEアカウントを紐付けます。既に紐付いている場合は情報を更新します。"},
 		{"出勤", "現在時刻で出勤打刻を登録します。"},
+		{"退勤", "現在時刻で退勤打刻を登録します。"},
+		{"休憩開始", "現在時刻で休憩開始の打刻を登録します。"},
+		{"休憩終了", "現在時刻で休憩終了の打刻を登録します。"},
 	}
 
 	var sb strings.Builder
@@ -134,6 +140,21 @@ func register(e webhook.MessageEvent, tokens []string) {
 }
 
 func clockIn(e webhook.MessageEvent, tokens []string) {
+	clock(e, tokens, models.ClockIn, "出勤")
+}
+
+func clockOut(e webhook.MessageEvent, tokens []string) {
+	clock(e, tokens, models.ClockOut, "退勤")
+}
+
+func breakBegin(e webhook.MessageEvent, tokens []string) {
+	clock(e, tokens, models.BreakBegin, "休憩開始")
+}
+func breakEnd(e webhook.MessageEvent, tokens []string) {
+	clock(e, tokens, models.BreakEnd, "休憩終了")
+}
+
+func clock(e webhook.MessageEvent, _ []string, clockType models.TimeClockType, clockName string) {
 	lineUserId, ok := services.GetLineUserId(e.Source)
 	if !ok {
 		services.Reply(e.ReplyToken, "ユーザー情報の取得に失敗しました。")
@@ -153,7 +174,7 @@ func clockIn(e webhook.MessageEvent, tokens []string) {
 	var ngList []string
 
 	for _, emp := range employees {
-		_, err := services.RecordTimeClock(emp.ID, models.ClockIn, now)
+		_, err := services.RecordTimeClock(emp.ID, clockType, now)
 		info := fmt.Sprintf("%sさん", emp.Name)
 		if err != nil {
 			log.Println(err)
@@ -167,20 +188,20 @@ func clockIn(e webhook.MessageEvent, tokens []string) {
 	// 登録が1人だけの場合はシンプルなメッセージにする
 	if len(employees) == 1 {
 		if len(okList) == 1 {
-			sb.WriteString(fmt.Sprintf("%sの出勤打刻を行いました！", okList[0]))
+			sb.WriteString(fmt.Sprintf("%sの%s打刻を行いました！", okList[0], clockName))
 		} else {
-			sb.WriteString(fmt.Sprintf("%sの出勤打刻に失敗しました...", ngList[0]))
+			sb.WriteString(fmt.Sprintf("%sの%s打刻に失敗しました...", ngList[0], clockName))
 		}
 	} else {
 		// 複数人いる場合のみリスト表示する
 		if len(okList) > 0 {
-			sb.WriteString("以下の従業員の出勤打刻を行いました！\n")
+			sb.WriteString(fmt.Sprintf("以下の従業員の%s打刻を行いました！\n", clockName))
 			for _, info := range okList {
 				sb.WriteString("・" + info + "\n")
 			}
 		}
 		if len(ngList) > 0 {
-			sb.WriteString("\n以下の従業員の出勤打刻に失敗しました。\n")
+			sb.WriteString(fmt.Sprintf("以下の従業員の%s打刻に失敗しました。\n", clockName))
 			for _, info := range ngList {
 				sb.WriteString("・" + info + "\n")
 			}

--- a/api/controllers/line_controller.go
+++ b/api/controllers/line_controller.go
@@ -19,6 +19,31 @@ var cmdMap = map[string]lineCmd{
 	"テスト": test,
 }
 
+func usage() string {
+	type help struct {
+		Cmd  string
+		Desc string
+	}
+
+	helps := []help{
+		{"登録 <社員ID> <名前>", "従業員とLINEアカウントを紐付けます。既に紐付いている場合は情報を更新します。"},
+		{"出勤", "現在時刻で出勤打刻を登録します。"},
+	}
+
+	var sb strings.Builder
+	sb.WriteString("==============================\n")
+	sb.WriteString("ご利用ガイド\n")
+	sb.WriteString("==============================\n\n")
+
+	for _, c := range helps {
+		sb.WriteString(c.Cmd + "\n")
+		sb.WriteString("    └ " + c.Desc + "\n\n")
+	}
+
+	sb.WriteString("※ コマンドは半角スペースで区切って送信してください。")
+	return sb.String()
+}
+
 func HandleLineWebhook(channelSecret string) gin.HandlerFunc {
 	handler, err := webhook.NewWebhookHandler(channelSecret)
 	if err != nil {
@@ -37,7 +62,7 @@ func HandleLineWebhook(channelSecret string) gin.HandlerFunc {
 				tokens := strings.Fields(text)
 
 				if len(tokens) == 0 {
-					services.Reply(e.ReplyToken, "メッセージを送信してください。")
+					services.Reply(e.ReplyToken, usage())
 					return
 				}
 
@@ -47,7 +72,7 @@ func HandleLineWebhook(channelSecret string) gin.HandlerFunc {
 					return
 				}
 
-				services.Reply(e.ReplyToken, "定義されていません。")
+				services.Reply(e.ReplyToken, usage())
 			}
 		}
 	})
@@ -57,7 +82,7 @@ func HandleLineWebhook(channelSecret string) gin.HandlerFunc {
 	}
 }
 
-func test(e webhook.MessageEvent, tokens []string) {
+func test(e webhook.MessageEvent, _ []string) {
 	services.Reply(e.ReplyToken, "接続OK!")
 }
 

--- a/api/services/line_bot.go
+++ b/api/services/line_bot.go
@@ -17,7 +17,7 @@ func InitLineBot(cfg *config.Config) {
 	LineBot = bot
 }
 
-func GetUserId(source webhook.SourceInterface) (string, bool) {
+func GetLineUserId(source webhook.SourceInterface) (string, bool) {
 	switch s := source.(type) {
 	case webhook.UserSource:
 		return s.UserId, true

--- a/api/services/time_clock_services.go
+++ b/api/services/time_clock_services.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"github.com/t2469/attendance-system.git/db"
+	"github.com/t2469/attendance-system.git/models"
+	"time"
+)
+
+func RecordTimeClock(empId uint, clockType models.TimeClockType, timestamp time.Time) (models.TimeClock, error) {
+	timeClock := models.TimeClock{
+		EmployeeID: empId,
+		Type:       clockType,
+		Timestamp:  timestamp,
+	}
+
+	if err := db.DB.Create(&timeClock).Error; err != nil {
+		return timeClock, err
+	}
+
+	day := timestamp.Truncate(24 * time.Hour)
+	if err := UpsertWorkRecord(empId, day); err != nil {
+		return timeClock, err
+	}
+
+	return timeClock, nil
+}


### PR DESCRIPTION
### コマンド処理の改善
- `lineCmd` 型およびコマンドと処理関数を紐付ける `cmdMap` を導入。
- 利用可能なコマンドのガイドを提供する `usage` 関数を追加。
- `HandleLineWebhook` を更新し、コマンド解析と適切なハンドラ関数の呼び出しを実装。

---

### リファクタリング & 関数の分離
- `register`, `clockIn`, `clockOut`, `breakBegin`, `breakEnd` 関数を抽出し、各コマンドの処理を明確化・整理。  
  [[1]](diffhunk://#diff-519714b9808b1fa7a727900ce1ffa2a11802e3db5b34c1c521afbba44fbfe6c0R71-R104)  
  [[2]](diffhunk://#diff-519714b9808b1fa7a727900ce1ffa2a11802e3db5b34c1c521afbba44fbfe6c0R141-R211)
- 時間打刻系の共通ロジックを扱う `clock` 関数を新規作成。

---

### サービス層の強化
- `RecordTimeClock` 関数を `api/services/time_clock_services.go` に追加し、時間打刻処理と勤怠レコード更新を一括で管理。
- `CreateTimeClock`（`time_clock_controller.go`）を修正し、新しい `RecordTimeClock` を利用する形に変更。

---

